### PR TITLE
Refactor

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -491,17 +491,23 @@ var MERGEABLE_NODES = {};
  * @return {boolean}
  */
 function mergeable(node) {
-    if (node.type != 'text' || !node.position) {
+    var start;
+    var end;
+
+    if (node.type !== 'text' || !node.position) {
         return true;
     }
 
-    var start = node.position.start;
-    var end = node.position.end;
+    start = node.position.start;
+    end = node.position.end;
 
-    // Nodes that occupy more space than the size of their content
-    // cannot be merged.
-    return start.line != end.line ||
-        end.column - start.column == node.value.length;
+    /*
+     * Only merge nodes which occupy the same size as their
+     * `value`.
+     */
+
+    return start.line !== end.line ||
+        end.column - start.column === node.value.length;
 }
 
 /**
@@ -1596,13 +1602,18 @@ function renderBlock(type, value, position) {
 /**
  * Tokenise an escape sequence.
  *
+ * Note that `$1` can only contain escapable characters per
+ * the used method, e.g., `\n` is only included when
+ * `commonmark: true`.
+ *
  * @example
  *   tokenizeEscape(eat, '\\a', 'a');
  *
  * @param {function(string)} eat
  * @param {string} $0 - Whole escape.
  * @param {string} $1 - Escaped character.
- * @return {Node} - `escape` node.
+ * @return {Node} - `text` node, or `break` node if
+ *   commonmark and the value is `'\n'`.
  */
 function tokenizeEscape(eat, $0, $1) {
     if ($1 == '\n') {

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -65,27 +65,31 @@ var FENCE = /([`~])\1{2}/;
 var PROTOCOL = /^[a-z][a-z+.-]+:\/?/i;
 
 /*
- * A run of punctuation characters.
- */
-var PUNCTUATION = /[-!"#$%&'()*+,.\/:;<=>?@\[\\\]^`{|}~]+/g;
-
-/*
  * Characters.
  */
 
 var ANGLE_BRACKET_CLOSE = '>';
 var ANGLE_BRACKET_OPEN = '<';
 var ASTERISK = '*';
+var SLASH = '\/';
 var BACKSLASH = '\\';
 var CARET = '^';
 var COLON = ':';
+var SEMICOLON = ';';
 var DASH = '-';
 var DOT = '.';
+var COMMA = ',';
 var EMPTY = '';
 var EQUALS = '=';
 var EXCLAMATION_MARK = '!';
+var QUESTION_MARK = '?';
 var HASH = '#';
+var DOLLAR = '$';
+var PERCENTAGE = '%';
+var AMPERSAND = '&';
 var LINE = '\n';
+var CARRIAGE = '\r';
+var FORM_FEED = '\f';
 var PARENTHESIS_OPEN = '(';
 var PARENTHESIS_CLOSE = ')';
 var PIPE = '|';
@@ -93,10 +97,15 @@ var PLUS = '+';
 var QUOTE_DOUBLE = '"';
 var QUOTE_SINGLE = '\'';
 var SPACE = ' ';
+var TAB = '\t';
+var VERTICAL_TAB = '\u000B';
 var SQUARE_BRACKET_OPEN = '[';
 var SQUARE_BRACKET_CLOSE = ']';
+var BRACKET_OPEN = '{';
+var BRACKET_CLOSE = '}';
 var TICK = '`';
 var TILDE = '~';
+var AT = '@';
 var UNDERSCORE = '_';
 
 /*
@@ -308,50 +317,134 @@ function escapeFactory(options) {
      * @return {string}
      */
     return function escape (value, node, parent) {
-        var escaped = value
-            .replace(/[\\`*\[_]/g, '\\$&')
-            .replace(/(\n\s*)([->])/g, '$1\\$2');
-        if (options.commonmark) {
-            escaped = escaped
-                .replace(/</g, '\\$&')
-                .replace(/(https?)(:)/g, '$1\\$2');
+        var siblings = parent && parent.children;
+        var commonmark = options.commonmark;
+        var length = value.length;
+        var escaped = value;
+        var position = -1;
+        var afterNewLine = true;
+        var queue = '';
+        var index;
+        var prev;
+        var character;
+
+        if (prev) {
+            afterNewLine = prev.type === 'text' && /\n\s*$/.test(prev.value)
+        } else if (parent) {
+            afterNewLine = parent.type === 'paragraph';
         }
 
-        // Multi-node versions.
-        if (node.type == 'text' && parent) {
-            var index = parent.children.indexOf(node);
-            var previous = parent.children[index - 1];
-            var match;
+        while (++position < length) {
+            character = value.charAt(position);
 
-            if ((match = value.match(/^\s*([->])/)) &&
-                (previous ?
-                 previous.type == 'text' && /\n\s*$/.test(previous.value) :
-                 parent.type == 'paragraph'))
-            {
-                escaped = escaped.replace(match[1], '\\' + match[1]);
-            }
-
-            if (value[0] == '(' && previous &&
-                previous.type == 'linkReference' &&
-                previous.referenceType == 'shortcut')
-            {
-                escaped = '\\' + escaped;
-            }
-
-            if (value[0] == ':' && previous.type == 'text') {
-                // Unlike previous cases, the context for this pattern can be
-                // split across more than a single text node.
-                var before = '', i = index - 1;
-                do {
-                    before = parent.children[i].value + before;
-                } while (
-                    before.length < 5 &&
-                    --i >= 0 &&
-                    parent.children[i].type == 'text'
+            if (
+                character === BACKSLASH ||
+                character === TICK ||
+                character === ASTERISK ||
+                character === SQUARE_BRACKET_OPEN ||
+                character === UNDERSCORE ||
+                (
+                    commonmark &&
+                    (
+                        character === ANGLE_BRACKET_OPEN ||
+                        (
+                            character === COLON &&
+                            (
+                                queue.slice(-4) === 'http' ||
+                                queue.slice(-5) === 'https'
+                            )
+                        )
+                    )
                 )
+            ) {
+                queue += BACKSLASH;
+            } else if (character === LINE) {
+                afterNewLine = true;
+            } else if (afterNewLine) {
+                if (
+                    character === ANGLE_BRACKET_CLOSE ||
+                    character === DASH
+                ) {
+                    queue += BACKSLASH;
+                } else if (
+                    character !== SPACE &&
+                    character !== TAB &&
+                    character !== CARRIAGE &&
+                    character !== VERTICAL_TAB &&
+                    character !== FORM_FEED
+                ) {
+                    afterNewLine = false
+                }
+            }
 
-                if (/https?$/.test(before)) {
-                    escaped = '\\' + escaped;
+            queue += character;
+        }
+
+        escaped = queue;
+
+        /*
+         * Multi-node versions.
+         */
+
+        if (siblings && node.type == 'text') {
+            index = siblings.indexOf(node);
+            prev = siblings[index - 1];
+
+            /*
+             * Check for an opening parentheses after a
+             * link-reference (which can be joined by
+             * white-space).
+             */
+
+            if (
+                prev &&
+                prev.type == 'linkReference' &&
+                prev.referenceType == 'shortcut'
+            ) {
+                position = -1;
+                length = escaped.length;
+
+                while (++position < length) {
+                    character = escaped.charAt(position);
+
+                    if (character === SPACE || character === TAB) {
+                        continue;
+                    }
+
+                    if (character === PARENTHESIS_OPEN) {
+                        escaped = escaped.slice(0, position) +
+                            BACKSLASH + escaped.slice(position);
+                    }
+
+                    break;
+                }
+            }
+
+            /*
+             * Ensure non-auto-links are not seen links.
+             * This pattern needs to check the preceding
+             * nodes too.
+             */
+
+            if (prev && prev.type == 'text' && value.charAt(0) == COLON) {
+                queue = '';
+                position = index;
+
+                while (position--) {
+                    if (
+                        siblings[position].type !== 'text' ||
+                        queue.length > 5
+                    ) {
+                        break;
+                    }
+
+                    queue = siblings[position].value + queue;
+                }
+
+                queue = queue.slice(-5);
+
+                if (queue === 'https' || queue.slice(-4) === 'http') {
+                    escaped = BACKSLASH + escaped;
                 }
             }
         }
@@ -1435,15 +1528,20 @@ compilerPrototype.link = function (node) {
         PROTOCOL.test(url) &&
         (url === value || url === MAILTO + value)
     ) {
-        // Backslash escapes do not work in autolinks.
+        /*
+         * Backslash escapes do not work in autolinks,
+         * so we do not escape.
+         */
+
         return encloseURI(self.encode(node.href), true);
     }
 
     url = encloseURI(url);
 
     if (node.title) {
-        var encodedTitle = self.encode(self.escape(node.title, node), node);
-        url += SPACE + encloseTitle(encodedTitle);
+        url += SPACE + encloseTitle(self.encode(self.escape(
+            node.title, node
+        ), node));
     }
 
     value = SQUARE_BRACKET_OPEN + value + SQUARE_BRACKET_CLOSE;
@@ -1504,8 +1602,9 @@ function label(node) {
 }
 
 /**
- * For shortcut reference links, link body is also an identifier,
- * and for identifiers extra backslashes do matter.
+ * For shortcut reference links, the contents is also an
+ * identifier, and for identifiers extra backslashes do
+ * matter.
  *
  * This function takes an escaped value from shortcut's children
  * and an identifier and removes extra backslashes.
@@ -1520,12 +1619,61 @@ function label(node) {
  * @return {string} - Link value with some characters unescaped.
  */
 function unescapeShortcutLinkReference(value, identifier) {
-    var canonicalPunctuation = identifier.match(PUNCTUATION);
-    var index = 0;
+    var index = -1;
+    var length = value.length;
+    var result = '';
+    var character;
+    var next;
 
-    return value.replace(PUNCTUATION, function () {
-        return canonicalPunctuation[index++];
-    });
+    while (++index < length) {
+        character = value.charAt(index);
+
+        if (identifier.charAt(index) === BACKSLASH) {
+            next = identifier.charAt(index + 1);
+
+            if (
+                next === DASH ||
+                next === EXCLAMATION_MARK ||
+                next === QUOTE_DOUBLE ||
+                next === QUOTE_SINGLE ||
+                next === HASH ||
+                next === DOLLAR ||
+                next === PERCENTAGE ||
+                next === AMPERSAND ||
+                next === PARENTHESIS_OPEN ||
+                next === PARENTHESIS_CLOSE ||
+                next === ASTERISK ||
+                next === PLUS ||
+                next === COMMA ||
+                next === DOT ||
+                next === COLON ||
+                next === SEMICOLON ||
+                next === SLASH ||
+                next === ANGLE_BRACKET_CLOSE ||
+                next === ANGLE_BRACKET_OPEN ||
+                next === EQUALS ||
+                next === QUESTION_MARK ||
+                next === AT ||
+                next === SQUARE_BRACKET_OPEN ||
+                next === SQUARE_BRACKET_CLOSE ||
+                next === BACKSLASH ||
+                next === CARET ||
+                next === TICK ||
+                next === BRACKET_OPEN ||
+                next === BRACKET_CLOSE ||
+                next === PIPE ||
+                next === TILDE
+            ) {
+                character = value.charAt(index + 1);
+                index++;
+            }
+        }
+
+        result += character;
+    }
+
+    console.log('result: ', [result, value, identifier]);
+    return result;
 }
 
 /**


### PR DESCRIPTION
Okay! Here goes. Most of this is just syntactic rewrite to how I like my code, which is just to ensure I don’t have to change small stuff in the future (e.g., setting variable declarations at the top of a scope, strict equality checks), but also because it helps me understand the code.

The most important change has to do with regexes: I’m trying to minimise those and rewrote the `escape` method to use an algorithm instead. I also tried my hand at `unescapeShortcutLinkRefer` (but didn’t get it working yet, and time is running out today). That’s a funky function, for example, I’m not sure what the `+` does in the regex for `PUNCTUATION`? Does it ensure the backslash is included?

Anyway, it doesn’t work yet, but I was hoping with your understanding of the regex and the function could get it to work? If not, just cherry pick this commit and ignore that function!
